### PR TITLE
Improve default vhost config

### DIFF
--- a/config/apache/sites-available/000-default.conf
+++ b/config/apache/sites-available/000-default.conf
@@ -1,5 +1,3 @@
-DocumentRoot ${APP_ROOT}/sites/
-
 <VirtualHost *:8080>
     use vhost
 

--- a/config/s6/cont-init.d/102-apache.sh
+++ b/config/s6/cont-init.d/102-apache.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bash
+
+file="${0##*/}"
+
+# Enable default vhost
+a2ensite 000-default -q | sed "s/^/[cont-init.d] ${file}: /"


### PR DESCRIPTION
This PR Closes #39 and uses `a2ensite` to enable the default vhost config. 